### PR TITLE
Fixed CoNLL parse failure on multiple blank lines

### DIFF
--- a/src/cnrs/rhapsodie/treebankbrowser/utils/Corpus.java
+++ b/src/cnrs/rhapsodie/treebankbrowser/utils/Corpus.java
@@ -23,8 +23,10 @@ public class Corpus {
 
 		while ((texte = lecteur.readLine()) != null) {
 			if (texte.length() == 0) {
-				phrases.add(phrase.toString());
-				phrase = new StringBuilder();
+				if (phrase.length() > 0){
+					phrases.add(phrase.toString());
+					phrase = new StringBuilder();
+				}
 				continue;
 			}
 			phrase.append( texte + "\n" );


### PR DESCRIPTION
Just a simple fix to ignore extraneous blank lines in CoNLL files.